### PR TITLE
Fix employee registration password hashing

### DIFF
--- a/app/Http/Controllers/AuthController.php
+++ b/app/Http/Controllers/AuthController.php
@@ -4,7 +4,6 @@ namespace App\Http\Controllers;
 
 use Illuminate\Http\Request;
 use Illuminate\Support\Facades\Auth;
-use Illuminate\Support\Facades\Hash; // <-- Added this line
 use App\Models\Employee;
 
 class AuthController extends Controller
@@ -83,7 +82,10 @@ public function register(Request $request)
     $employee = Employee::create([
         'name'     => $validatedData['name'],
         'email'    => $validatedData['email'],
-        'password' => Hash::make($validatedData['password']),
+        // The Employee model automatically hashes the password
+        // using the setPasswordAttribute mutator, so we can assign
+        // the plain text value here.
+        'password' => $validatedData['password'],
         'role'     => 'user' // Default role assigned
     ]);
 


### PR DESCRIPTION
## Summary
- avoid double hashing in registration flow by assigning plain text password
- remove unused Hash import

## Testing
- `composer install` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_686a5e8e47fc83279668b7001355bd3e