### PR TITLE
Fix auth provider defaults

### DIFF
--- a/config/auth.php
+++ b/config/auth.php
@@ -62,7 +62,11 @@ return [
     'providers' => [
         'users' => [
             'driver' => 'eloquent',
-            'model' => env('AUTH_MODEL', App\Models\User::class),
+            // Use the Employee model by default for authentication
+            // so that new installations work without requiring an
+            // ENV override.  The model can still be swapped by
+            // setting the AUTH_MODEL environment variable.
+            'model' => env('AUTH_MODEL', App\Models\Employee::class),
         ],
 
         // 'users' => [


### PR DESCRIPTION
## Summary
- use `Employee` model as the default auth provider

## Testing
- `composer install --no-interaction` *(fails: command not found)*
- `php artisan test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_686aa1c3bf7483278825451d77873213